### PR TITLE
Add Playwright MCP skill for browser automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository includes a diverse collection of example skills demonstrating di
 ## Development & Technical
 - **artifacts-builder** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **mcp-server** - Guide for creating high-quality MCP servers to integrate external APIs and services
+- **playwright-mcp** - Browser automation and web testing using Playwright MCP server for direct tool-based interactions
 - **webapp-testing** - Test local web applications using Playwright for UI verification and debugging
 
 ## Enterprise & Communication

--- a/playwright-mcp/LICENSE.txt
+++ b/playwright-mcp/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/playwright-mcp/SKILL.md
+++ b/playwright-mcp/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: playwright-mcp
+description: Guide for using the Playwright MCP (Model Context Protocol) server to perform browser automation, web testing, and UI verification through direct tool calls. Use when you need to interact with web applications, take screenshots, or test web interfaces without writing custom scripts.
+---
+
+# Playwright MCP Server
+
+The Playwright MCP server provides browser automation tools directly to Claude through the Model Context Protocol. Unlike the webapp-testing skill which requires writing Python scripts, the Playwright MCP enables browser automation through simple tool calls.
+
+## Installation
+
+To use the Playwright MCP server, add it to your Claude configuration:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+This adds the following configuration to `~/.config/claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+After adding the MCP server, restart Claude for the changes to take effect.
+
+## Available Tools
+
+The Playwright MCP server provides tools for:
+
+- **Browser Navigation**: Navigate to URLs and interact with web pages
+- **Element Interaction**: Click buttons, fill forms, and interact with UI elements
+- **Screenshot Capture**: Take screenshots of entire pages or specific elements
+- **Content Extraction**: Extract text, HTML, or specific data from web pages
+- **Page Evaluation**: Run JavaScript in the browser context
+- **Waiting & Timing**: Wait for elements, network requests, or specific conditions
+
+## When to Use Playwright MCP vs webapp-testing
+
+**Use Playwright MCP when:**
+- You need quick, interactive browser automation
+- Testing simple workflows or UI interactions
+- Taking screenshots for visual verification
+- Extracting data from web pages
+- You want Claude to handle browser automation directly
+
+**Use webapp-testing skill (Python scripts) when:**
+- You need complex, reusable test automation
+- Running tests as part of CI/CD pipelines
+- Managing multiple servers (frontend + backend)
+- Creating persistent test suites
+- You need fine-grained control over Playwright API
+
+## Example Usage Patterns
+
+### Basic Navigation and Screenshot
+```
+Navigate to https://example.com and take a screenshot of the homepage
+```
+
+### Form Interaction
+```
+Go to the login page, fill in the username "test@example.com" and password "password123", then click the login button
+```
+
+### Content Extraction
+```
+Navigate to the product page and extract all product names and prices
+```
+
+### Element Verification
+```
+Check if the "Add to Cart" button is visible on the product page
+```
+
+## Best Practices
+
+1. **Wait for Content**: Always ensure pages are fully loaded before interacting
+2. **Use Descriptive Selectors**: Prefer text-based selectors (e.g., "Click the 'Submit' button") over CSS selectors
+3. **Take Screenshots**: Capture screenshots to verify visual state when debugging
+4. **Handle Errors Gracefully**: Be prepared for elements that might not exist
+5. **Respect Rate Limits**: Don't overwhelm servers with rapid requests
+
+## Comparison with Other Approaches
+
+| Feature | Playwright MCP | webapp-testing | Manual Playwright Scripts |
+|---------|---------------|----------------|---------------------------|
+| Setup Complexity | Low | Medium | High |
+| Interactivity | High | Low | Medium |
+| Reusability | Medium | High | High |
+| CI/CD Integration | Low | High | High |
+| Learning Curve | Low | Medium | High |
+| Control Level | Medium | High | High |
+
+## Related Skills
+
+- **webapp-testing**: For complex, script-based Playwright automation
+- **artifacts-builder**: For creating interactive web UIs to test
+
+## Security Considerations
+
+- The Playwright MCP server can navigate to any URL and execute JavaScript
+- Only use it on trusted websites
+- Be cautious with sensitive information (passwords, API keys)
+- Screenshots may contain sensitive data - handle appropriately
+
+## Troubleshooting
+
+**MCP server not available:**
+- Ensure you've restarted Claude after adding the configuration
+- Verify the configuration in `~/.config/claude/claude_desktop_config.json`
+- Check that `npx` is available in your PATH
+
+**Browser not launching:**
+- Ensure Playwright browsers are installed: `npx playwright install`
+- Check for permission issues with browser binaries
+
+**Timeout errors:**
+- Increase timeout values for slow-loading pages
+- Ensure network connectivity
+- Verify the target website is accessible


### PR DESCRIPTION
This commit adds a new skill that documents how to use the Playwright MCP (Model Context Protocol) server for browser automation and web testing.

Changes:
- Created playwright-mcp/ skill directory with SKILL.md documentation
- Added LICENSE.txt (Apache 2.0) to playwright-mcp/
- Updated README.md to include playwright-mcp in Development & Technical section

The Playwright MCP skill provides:
- Installation instructions for the Playwright MCP server
- Comparison between MCP-based and script-based Playwright approaches
- Usage examples for common browser automation tasks
- Best practices and troubleshooting guidance
- Clear distinction from the existing webapp-testing skill

This complements the existing webapp-testing skill by offering a simpler, tool-based approach to browser automation for quick interactions and tests.