### PR TITLE
Add prompt-to-asset (Creative & Design) and unslop (Enterprise & Communication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository includes a diverse collection of example skills demonstrating di
 ## Creative & Design
 - **algorithmic-art** - Create generative art using p5.js with seeded randomness, flow fields, and particle systems
 - **canvas-design** - Design beautiful visual art in .png and .pdf formats using design philosophies
+- **[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** - MCP server that generates production-ready visual assets (app icons, favicons, OG images) across 30+ image generation models
 - **slack-gif-creator** - Create animated GIFs optimized for Slack's size constraints
 
 ## Development & Technical
@@ -41,6 +42,7 @@ This repository includes a diverse collection of example skills demonstrating di
 - **brand-guidelines** - Apply Anthropic's official brand colors and typography to artifacts
 - **internal-comms** - Write internal communications like status reports, newsletters, and FAQs
 - **theme-factory** - Style artifacts with 10 pre-set professional themes or generate custom themes on-the-fly
+- **[unslop](https://github.com/MohamedAbdallah-14/unslop)** - Strip AI writing patterns (sycophancy, stock vocab, hedging) from Claude output before publishing
 
 ## Meta Skills
 - **skill-creator** - Guide for creating effective skills that extend Claude's capabilities


### PR DESCRIPTION
## Add prompt-to-asset and unslop

Two community tools that fit the existing categories:

**Creative & Design: prompt-to-asset**
- Repo: https://github.com/MohamedAbdallah-14/prompt-to-asset
- npm: `prompt-to-asset`
- MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, and full API generation. Zero API key required for first run via free tiers.

**Enterprise & Communication: unslop**
- Repo: https://github.com/MohamedAbdallah-14/unslop
- npm: `unslop`
- Claude Code plugin + CLI that strips AI writing patterns from output before publishing. Removes sycophantic openers, stock vocabulary, hedging stacks, and em-dash pileups. Engineers sentence burstiness. Code and URLs pass through unchanged.