### PR TITLE
Add awesome-claude-code-hooks to related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+
+# Related Lists
+
+- [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) - a curated list of hooks, guides, and tools for Claude Code hooks (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more)


### PR DESCRIPTION
Adding a link to https://github.com/loqimean/awesome-claude-code-hooks, a curated list of hooks, guides, and tools for Claude Code hooks (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more). Thought it fits well next to the Notion skills link since it's another community resource for extending Claude Code.